### PR TITLE
Don't strip spaces from output of pandoc

### DIFF
--- a/lib/pandoc-ruby.rb
+++ b/lib/pandoc-ruby.rb
@@ -101,7 +101,7 @@ private
     Open3::popen3(command) do |stdin, stdout, stderr| 
       stdin.puts @target 
       stdin.close
-      output = stdout.read.strip 
+      output = stdout.read 
     end
     output
   end


### PR DESCRIPTION
For markups like Markdown, spaces in output can potentially be significant (e.g. code). Therefore, they should not be stripped. Here is an example test case that shows how it was broken:

Before fix:

```
> puts PandocRuby.convert("<p><pre><code>line 1\nline 2</code></pre></p>", from: 'html', to: 'markdown')
line 1
    line 2
```

After fix:

```
> puts PandocRuby.convert("<p><pre><code>line 1\nline 2</code></pre></p>", from: 'html', to: 'markdown')
    line 1
    line 2
```
