### PR TITLE
Now supports direct binary output.

### DIFF
--- a/test/test_pandoc-ruby.rb
+++ b/test/test_pandoc-ruby.rb
@@ -109,6 +109,17 @@ class TestPandocRuby < Test::Unit::TestCase
     end
   end
   
+  PandocRuby::BINARY_WRITERS.each_key do |w|
+    should "convert to #{w} with to_#{w}" do
+      converter = PandocRuby.new(@file)
+      converter \
+        .expects(:execute) \
+        .with(regexp_matches(/^pandoc --no-wrap --to=#{w} --output=/)) \
+        .returns(true)
+      assert converter.send("to_#{w}", :no_wrap)
+    end
+  end
+  
   should "work with strings" do
     converter = PandocRuby.new('## this is a title')
     assert_match %r(h2), converter.convert
@@ -148,7 +159,6 @@ class TestPandocRuby < Test::Unit::TestCase
       "mediawiki"     =>  "MediaWiki markup",
       "html"          =>  "HTML",
       "plain"         =>  "plain",
-      "docx"          =>  "docx",
       "latex"         =>  "LaTeX",
       "s5"            =>  "S5 HTML slideshow",
       "textile"       =>  "textile",
@@ -156,7 +166,6 @@ class TestPandocRuby < Test::Unit::TestCase
       "docbook"       =>  "DocBook XML",
       "html5"         =>  "HTML5",
       "native"        =>  "pandoc native",
-      "epub"          =>  "epub",
       "org"           =>  "emacs org mode",
       "rtf"           =>  "rich text format",
       "markdown"      =>  "markdown",
@@ -168,8 +177,14 @@ class TestPandocRuby < Test::Unit::TestCase
       "slidy"         =>  "Slidy HTML slideshow",
       "rst"           =>  "reStructuredText",
       "context"       =>  "ConTeXt",
-      "odt"           =>  "odt",
       "asciidoc"      =>  "asciidoc"
+    }
+
+    assert_equal PandocRuby::BINARY_WRITERS, {
+      "odt"   => "OpenDocument",
+      "docx"  => "Word docx",
+      "epub"  => "EPUB V2",
+      "epub3" => "EPUB V3"
     }
 
   end


### PR DESCRIPTION
pandoc supports several binary output formats (i.e. odt, docx, epub, and epub3), however pandoc requires these to output to files instead of dumping the binary to standard output. From the [README](http://johnmacfarlane.net/pandoc/README.html):

> Output goes to stdout by default (though output to stdout is disabled for the odt, docx, epub, and epub3 output formats).

This pull request eliminates this restriction by outputting the binary directly to standard output for odt, docx, epub, and epub3 output formats. (It also adds the missing epub3 output format.)

Benefits:
- binary support!
- the API now works consistently across all output formats
- much easier in cases where you want to dynamically serve some exported data in a variety of formats to a users of your web application, i.e. no more fiddling with files
