### PR TITLE
Wrap filenames in single quotes before handing them to pandoc

### DIFF
--- a/lib/pandoc-ruby.rb
+++ b/lib/pandoc-ruby.rb
@@ -179,7 +179,7 @@ class PandocRuby
     when String
       self.input_string = args.shift
     when Array
-      self.input_files  = args.shift.join(' ')
+      self.input_files  = args.shift.map{ |f| "'#{f}'"}.join(' ')
     end
 
     self.options = args


### PR DESCRIPTION
Fixes #45 